### PR TITLE
[arguments] support parsable flag

### DIFF
--- a/simple_slurm/arguments.txt
+++ b/simple_slurm/arguments.txt
@@ -70,6 +70,7 @@ open_mode
 output,o
 overcommit,O
 oversubscribe,s
+parsable
 partition,p
 power
 prefer


### PR DESCRIPTION
## Motivation

Firstly, thanks for sharing the library! We appreciate it greatly. This PR adds the ability to use the parsable arg, as described in the sbatch [manpage](https://slurm.schedmd.com/sbatch.html#OPT_parsable). We extend the simple slurm `Slurm` object in our code base for some additional functionality. In one of our classes, we rather scrape output from the sbatch `--parsable` flag. We can extend this functionality without a problem, but figured it might be useful to upstream incase other people want to extend the class and use parsable output.

## Testing

  - add unit test: `pytest test/test_core.py::Testing::test_20_parsable_sbatch_execution`
  - Test on internal cluster

## Caveats

Note that `srun` doesn't accept this argument and will throw a cmdline argument if invoked. We can do one of the following:

- [2nd easiest] Add an exception set in the constructor for sbatch/srun only arguments
- [easiest] let the cmdline yield proper feedback (do nothing)
- [most extensible] Add a special extended parser for sbatch, using `sbatch_arguments.txt` and use that parser on sbatch invocations.

Let me know how/if you want to handle this.